### PR TITLE
fix: fixing the word "libaries" to "libraries" in file src/3bc.h

### DIFF
--- a/src/3bc.h
+++ b/src/3bc.h
@@ -4,7 +4,7 @@
 /** prepare **/
 #include "3bc_macros.h"
 
-/** libaries **/
+/** libraries **/
 #include <math.h>
 #include <ctype.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixing the word "libaries" to "libraries" in file src/3bc.h.
And resolving issue #181

@RodrigoDornelles