### PR TITLE
Add build binary output file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ docs:
 	@cd docs && bundle exec jekyll serve --watch --incremental --livereload
 	
 build:
-	@${CC} ${SOURCES} ${CFLAGS} ${LDFLAGS}
+	@${CC} ${SOURCES} ${CFLAGS} ${LDFLAGS} -o 3bc
 
 tests: tests-clear tests-build tests-unit
 	@


### PR DESCRIPTION
At https://3bc-lang.org/guide/tutorial-pt-br the run command should be 3bc.