### PR TITLE
fixed: bug than 255 vm initied

### DIFF
--- a/src/3bc_types.h
+++ b/src/3bc_types.h
@@ -9,7 +9,15 @@ typedef unsigned char label_3bc_t;
 typedef unsigned char memory_conf_t;
 typedef signed int data_3bc_t;
 typedef signed long data_aux_3bc_t;
+#if defined(__x86_64__)
+typedef unsigned long long app_3bc_id;
+#elif defined(__x86_64__)
+typedef unsigned long app_3bc_id;
+#elif defined (ESP_PLATFORM) || defined(ARDUINO_ARCH_RP2040)
+typedef unsigned int app_3bc_id;
+#else
 typedef unsigned char app_3bc_id;
+#endif
 
 /** FILE/STREAM/INTERFACE TYPES **/
 typedef FILE file_t;


### PR DESCRIPTION
# Description

solved infinite loop issue after booting more than 255 virtual machines in the same process.

Fixes #272

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

a benchmark was made to test the new limit, it was stopped by the kernel for system security reasons.

 * **System:** MacOS Catalina 10.15.7
 * **CPU:** 2,5 GHz Dual-Core Intel Core i5
 * **RAM**  16 GB 1600 MHz DDR3

```
Machines: 85.426.176 Time: 7:16.20  (227.68s interrupt 203.86s process) Mem: 4GB CPU: 98%
```
