### PR TITLE
fix: remove 'const' modifier on return types

### DIFF
--- a/src/driver_power.c
+++ b/src/driver_power.c
@@ -40,9 +40,9 @@
  * MACRO: lang_3bc_init
  */
 #if !defined(TBC_NOT_ARGCV)
-struct app_3bc_s* const driver_power_init(int argc, char** argv)
+struct app_3bc_s* driver_power_init(int argc, char** argv)
 #else
-struct app_3bc_s* const driver_power_init()
+struct app_3bc_s* driver_power_init()
 #endif
 {
     struct app_3bc_s* const app = ds_hypervisor_darray_new();

--- a/src/ds_hypervisor_darray.c
+++ b/src/ds_hypervisor_darray.c
@@ -44,7 +44,7 @@ static struct app_3bc_s** machines_array;
 /**
  * Expand number of virtual machines
  */
-struct app_3bc_s* const ds_hypervisor_darray_new()
+struct app_3bc_s* ds_hypervisor_darray_new()
 {
     struct app_3bc_s* new_vm
         = (struct app_3bc_s* const)malloc(sizeof(struct app_3bc_s));
@@ -83,7 +83,7 @@ struct app_3bc_s* const ds_hypervisor_darray_new()
 /**
  * RETURN: virutal machine by id
  */
-struct app_3bc_s* const ds_hypervisor_darray_get_one(app_3bc_id app)
+struct app_3bc_s* ds_hypervisor_darray_get_one(app_3bc_id app)
 {
     return machines_array[app];
 }


### PR DESCRIPTION
# Description

A 'const' modifier on a function return type is useless and should be removed for clarity.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
