### PR TITLE
Windows: fix incompatible pointer types

### DIFF
--- a/src/sys/sys_windows_output.c
+++ b/src/sys/sys_windows_output.c
@@ -1,25 +1,40 @@
+#ifdef __MINGW32__
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 #include "sys_windows_output.h"
 
 void sys_windows_output(tbc_app_st *const self)
 {
-    static LPDWORD ruindows;
-    static HANDLE fileptr = GetStdHandle(STD_OUTPUT_HANDLE);
+    static HANDLE fileptr = NULL;
+
+    // Initialize the fileptr if it hasn't been initialized before
+    if (fileptr == NULL) {
+        fileptr = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (fileptr == INVALID_HANDLE_VALUE) {
+            // Handle error if GetStdHandle fails
+            // (you might want to handle the error accordingly)
+            return;
+        }
+    }
 
     if (self->cache_l3.fixbuf.size > 0) {
+        DWORD bytesWritten;
         WriteFile(
             fileptr,
             self->cache_l3.fixbuf.storage,
-            self->cache_l3.fixbuf.size, 
-            &ruindows,
+            self->cache_l3.fixbuf.size,
+            &bytesWritten,
             NULL
         );
     } else {
+        DWORD bytesWritten;
         WriteFile(
             fileptr,
             self->cache_l3.fixbuf.storage,
-            -self->cache_l3.fixbuf.size, 
-            &ruindows,
+            -self->cache_l3.fixbuf.size,
+            &bytesWritten,
             NULL
         );
     }


### PR DESCRIPTION
#### error

https://github.com/kassane/3bc-zig/actions/runs/5601555100/jobs/10245605430#step:4:9

```bash
Debug native-windows: error: error(compilation): clang failed with stderr: In file included from /home/kassane/Documentos/3bc_learn/3bc-z/dep/3bc-lang.git/src/sys/sys_windows_output.c:6:
In file included from /home/kassane/Documentos/3bc_learn/3bc-z/dep/3bc-lang.git/src/sys/sys_windows_output.h:4:
In file included from /home/kassane/Documentos/3bc_learn/3bc-z/dep/3bc-lang.git/src/3bc_types.h:46:
/home/kassane/Documentos/3bc_learn/3bc-z/dep/3bc-lang.git/src/types/types_tty.h:117:7: warning: no newline at end of file [-Wnewline-eof]
/home/kassane/Documentos/3bc_learn/3bc-z/dep/3bc-lang.git/src/sys/sys_windows_output.c:11:29: error: initializer element is not a compile-time constant
/home/kassane/Documentos/3bc_learn/3bc-z/dep/3bc-lang.git/src/sys/sys_windows_output.c:18:13: warning: incompatible pointer types passing 'LPDWORD *' (aka 'unsigned long **') to parameter of type 'LPDWORD' (aka 'unsigned long *'); remove & [-Wincompatible-pointer-types]
/home/kassane/zig/0.11.0-dev.4010+70c71935c/files/lib/libc/include/any-windows-any/fileapi.h:186:109: note: passing argument to parameter 'lpNumberOfBytesWritten' here
/home/kassane/Documentos/3bc_learn/3bc-z/dep/3bc-lang.git/src/sys/sys_windows_output.c:26:13: warning: incompatible pointer types passing 'LPDWORD *' (aka 'unsigned long **') to parameter of type 'LPDWORD' (aka 'unsigned long *'); remove & [-Wincompatible-pointer-types]
/home/kassane/zig/0.11.0-dev.4010+70c71935c/files/lib/libc/include/any-windows-any/fileapi.h:186:109: note: passing argument to parameter 'lpNumberOfBytesWritten' here
```

MinGW not detect `Windows.h`, but `windows.h`!

cc: @RodrigoDornelles 